### PR TITLE
NG-529 fix: npm publish should be with public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@aws-sdk/credential-provider-sso": "^3.25.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
NPM publish should have access set to public