### PR TITLE
fix: insomnia author logo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "publisher": {
       "name": "Phocas Engineering",
-      "icon": "https://github.com/phocassoftware/aws-sso-insomnia-plugin/tree/main/images/icons/phocas-engineering-full.svg"
+      "icon": "https://raw.githubusercontent.com/phocassoftware/aws-sso-insomnia-plugin/main/images/icons/phocas-engineering-full.svg"
     },
     "applications": {
       "designer": "*",


### PR DESCRIPTION
The last image to be moved over to `raw.githubusercontent.com` is in the package.json object consumed by Insomnia for the plugins page